### PR TITLE
Update service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 ---
 # https://services.shopify.io/services/shopify-snap/production
-director: jacklar
+director: dneufeld
 owners:
-- Shopify/support-operations
+- Shopify/dev-acceleration
 classification: tier3


### PR DESCRIPTION
This seems to be a tool that is used by Spy to do some stuff, but I think it was mistakenly set to be owned by our team.

Maybe kit shouldn't be owned by dev-acceleration but it makes more sense for an RnD team to own it vs Support based on how its used.

