### PR TITLE
Move shopify-snap to support-dev team

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -1,6 +1,6 @@
 ---
 # https://services.shopify.io/services/shopify-snap/production
-director: dneufeld
+director: jacklar
 owners:
-- Shopify/dev-acceleration
+- @Shopify/support-dev
 classification: tier3


### PR DESCRIPTION
This was assigned to dev-accel for unknown reasons. Let's correct it!

@jacklar @Shopify/support-dev cc @jarthorn @RyanBrushett 