### PR TITLE
add contains_pii to service.yml

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -4,3 +4,6 @@ director: jacklar
 owners:
 - @Shopify/support-dev
 classification: tier3
+security:
+  data_management:
+    contains_pii: true


### PR DESCRIPTION
**What are you trying to accomplish with this PR?**
We are starting to track the services that contain PII (PII = personally identifiable information, or any data that could be associated to a single person). I'm adding this service to the list of ones we've reviewed.

**How is this accomplished?**
I made a small change to the service.yml to let service-db know that this service **does indeed** contain pii. This will be done across all services so that we can have better visibility into where our PII is stored.

See Shopify/services-db#868 for a bit more context

**What could go wrong? (if anything)**
Nothing serious. It's a change to the service.yml.

**Rollback steps**
 - [X] It is safe to simply rollback this change

@jay-ro - FYI
@Shopify/support-dev 